### PR TITLE
Fixes Requirement Installation with enum.

### DIFF
--- a/get5_auto_installer.sh
+++ b/get5_auto_installer.sh
@@ -367,6 +367,11 @@ case $option in
 
 			virtualenv venv
 			source venv/bin/activate
+
+			#Change Setup Tools to lower version for Supporting enum
+			pip install --upgrade 'setuptools==44.1.0'
+		
+			#Install Requirements
 			pip install -r requirements.txt
 			
 


### PR DESCRIPTION
With Python 2.7 on EOL from 1 Jan 2020, virtualenv creates new Setuptools to 45.0.0 by default and enum==0.4.6 is already added in 45.0.0 and will give error on requirements.txt installation area. So with this small update it should downgrade setuptools to 44.1.1 version which is working perfectly with Python 2.7